### PR TITLE
corregida la dinamica de activacion de un nuevo profesional

### DIFF
--- a/app/Http/Controllers/Auth/PasswordResetLinkController.php
+++ b/app/Http/Controllers/Auth/PasswordResetLinkController.php
@@ -29,9 +29,6 @@ class PasswordResetLinkController extends Controller
             'email' => ['required', 'email'],
         ]);
 
-        // We will send the password reset link to this user. Once we have attempted
-        // to send the link, we will examine the response then see the message we
-        // need to show to the user. Finally, we'll send out a proper response.
         $status = Password::sendResetLink(
             $request->only('email')
         );

--- a/app/Http/Controllers/ProfesionalController.php
+++ b/app/Http/Controllers/ProfesionalController.php
@@ -138,6 +138,49 @@ class ProfesionalController extends Controller {
         return redirect()->route('usuarios.principal')->with($mensaje);
     }
 
+    public function reenviarMailActivacion(int $id): RedirectResponse
+    {
+        try {
+            $this->profesionalService->reenviarMailActivacion($id);
+            return redirect()->route('usuarios.principal')
+                ->with('success', 'Correo de activación reenviado correctamente.');
+        } catch (\InvalidArgumentException $e) {
+            return redirect()->route('usuarios.principal')
+                ->with('error', $e->getMessage());
+        } catch (\Exception $e) {
+            return redirect()->route('usuarios.principal')
+                ->with('error', 'Error al reenviar el correo de activación.');
+        }
+    }
+
+    public function eliminarSinProfesion(int $id): RedirectResponse
+    {
+        try {
+            $profesional = $this->profesionalService->getProfesionalById($id);
+            
+            if (!$profesional) {
+                return redirect()->route('usuarios.principal')
+                    ->with('error', 'Usuario no encontrado.');
+            }
+
+            if ($profesional->profesion) {
+                return redirect()->route('usuarios.principal')
+                    ->with('error', 'Solo se pueden eliminar usuarios sin profesión asignada.');
+            }
+
+            if ($this->profesionalService->deleteProfesional($id)) {
+                return redirect()->route('usuarios.principal')
+                    ->with('success', 'Usuario eliminado correctamente.');
+            }
+
+            return redirect()->route('usuarios.principal')
+                ->with('error', 'No se pudo eliminar el usuario.');
+        } catch (\Exception $e) {
+            return redirect()->route('usuarios.principal')
+                ->with('error', 'Error al eliminar el usuario.');
+        }
+    }
+
     /*
     public function editar(int $id)
     {

--- a/app/Services/Implementations/ProfesionalService.php
+++ b/app/Services/Implementations/ProfesionalService.php
@@ -168,6 +168,7 @@ class ProfesionalService implements ProfesionalServiceInterface
                 'nombre' => $data['nombre'],
                 'apellido' => $data['apellido'],
                 'dni' => $data['dni'],
+                'activo' => false,
             ]);
 
             $usuarioGenerado = strtolower($data['nombre'] . '.' . $data['apellido']);
@@ -208,10 +209,11 @@ class ProfesionalService implements ProfesionalServiceInterface
 
         DB::beginTransaction();
         try {
-            // Actualizar persona
+            // Actualizar persona con activo = true
             $personaId = $prof->fk_id_persona;
             $this->personaService->updatePersona($personaId, [
                 'fecha_nacimiento' => $data['fecha_nacimiento'],
+                'activo' => true,
             ]);
 
             // Actualizar profesional
@@ -284,6 +286,34 @@ class ProfesionalService implements ProfesionalServiceInterface
         ]));
 
         return $this->updateProfesional($idProfesional, array_merge($personaFields, $profesionalFields));
+    }
+
+    public function reenviarMailActivacion(int $idProfesional): bool
+    {
+        $profesional = $this->repo->find($idProfesional);
+
+        if (!$profesional) {
+            throw new InvalidArgumentException('Profesional no encontrado.');
+        }
+
+        // Verificar que la cuenta no esté activada
+        if ($profesional->persona->activo) {
+            throw new InvalidArgumentException('La cuenta ya está activada.');
+        }
+
+        // Eliminar token anterior si existe
+        $this->repo->eliminarTokenReset($profesional->email);
+
+        // Generar y enviar nuevo token de activación
+        try {
+            \Password::broker('profesionales')->sendResetLink([
+                'email' => $profesional->email,
+            ]);
+            return true;
+        } catch (\Exception $e) {
+            \Log::error('Error al reenviar correo de activación: ' . $e->getMessage());
+            throw new InvalidArgumentException('Error al reenviar el correo de activación.');
+        }
     }
 
     private function normalizarTexto(string $texto): string {

--- a/app/Services/Implementations/ProfesionalService.php
+++ b/app/Services/Implementations/ProfesionalService.php
@@ -171,7 +171,10 @@ class ProfesionalService implements ProfesionalServiceInterface
                 'activo' => false,
             ]);
 
-            $usuarioGenerado = strtolower($data['nombre'] . '.' . $data['apellido']);
+            // Extraer primer nombre y primer apellido
+            $primerNombre = explode(' ', trim($data['nombre']))[0];
+            $primerApellido = explode(' ', trim($data['apellido']))[0];
+            $usuarioGenerado = strtolower($primerNombre . '.' . $primerApellido);
 
             if ($this->repo->existeUsuario($usuarioGenerado)) {
                 $usuarioGenerado .= rand(1, 99);

--- a/app/Services/Interfaces/ProfesionalServiceInterface.php
+++ b/app/Services/Interfaces/ProfesionalServiceInterface.php
@@ -28,4 +28,5 @@ interface ProfesionalServiceInterface
     public function actualizarContrasenia(int $idProfesional, string $newPassword): bool;
     public function resetContrasenia(string $email, string $token, string $newPassword): bool;
     public function actualizarPerfil(int $idProfesional, array $data): Profesional;
+    public function reenviarMailActivacion(int $idProfesional): bool;
 }

--- a/config/auth.php
+++ b/config/auth.php
@@ -55,7 +55,7 @@ return [
         'profesionales' => [ // CORREGIDO: Nuevo nombre del broker de contraseñas
             'provider' => 'profesionales',
             'table' => 'password_resets',
-            'expire' => 60,
+            'expire' => 4320, // 3 días (72 horas) en minutos
             'throttle' => 60,
         ],
     ],

--- a/database/factories/ProfesionalFactory.php
+++ b/database/factories/ProfesionalFactory.php
@@ -18,7 +18,10 @@ class ProfesionalFactory extends Factory
 
         $nombreSimulado = $this->faker->firstName();
         $apellidoSimulado = $this->faker->lastName();
-        $usuarioSimulado = strtolower(Str::slug($nombreSimulado . '.' . $apellidoSimulado));
+        // Extraer primer nombre y primer apellido (sin incluir espacios)
+        $primerNombre = explode(' ', trim($nombreSimulado))[0];
+        $primerApellido = explode(' ', trim($apellidoSimulado))[0];
+        $usuarioSimulado = strtolower($primerNombre . '.' . $primerApellido);
         $siglaAleatoria = $this->faker->randomElement(Siglas::cases());
 
         return [

--- a/resources/views/emails/activar-cuenta.blade.php
+++ b/resources/views/emails/activar-cuenta.blade.php
@@ -15,7 +15,7 @@ Para activar su cuenta y definir su contraseña, haga clic en el siguiente botó
 Activar cuenta
 </x-mail::button>
 
-Este enlace expirará en **{{ config('auth.passwords.profesionales.expire') }} minutos**.
+Este enlace expirará en **3 días**.
 
 Una vez creada su contraseña, deberá completar sus datos personales antes de acceder al sistema.
 

--- a/resources/views/usuarios/principal.blade.php
+++ b/resources/views/usuarios/principal.blade.php
@@ -83,15 +83,41 @@
                                 </td>
 
                                 <td class="p-4 text-center">
-                                    <div class="flex justify-center gap-2">
-                                        {!! view('components.boton-estado', [
-                                            'activo' => $usuario->persona->activo,
-                                            'route' => route('usuarios.cambiarActivo', $usuario->id_profesional),
-                                            'text_activo' => 'Desactivar',
-                                            'text_inactivo' => 'Activar',
-                                            'message_activo' => '¿Desea desactivar este usuario?',
-                                            'message_inactivo' => '¿Desea activar este usuario?',
-                                        ])->render() !!}
+                                    <div class="flex justify-center gap-2 flex-wrap">
+                                        {{-- Botones para usuario sin profesión asignada --}}
+                                        @if(!$usuario->profesion)
+                                            {{-- Botón Reenviar Correo --}}
+                                            <form method="POST" action="{{ route('usuarios.reenviarActivacion', $usuario->id_profesional) }}" class="inline">
+                                                @csrf
+                                                <button type="submit" 
+                                                        class="px-3 py-1 text-xs font-medium rounded-md bg-blue-100 text-blue-700 border border-blue-300 hover:bg-blue-200 transition"
+                                                        title="Reenviar correo de activación">
+                                                    Reenviar
+                                                </button>
+                                            </form>
+
+                                            {{-- Botón Eliminar --}}
+                                            <form method="POST" action="{{ route('usuarios.eliminarSinProfesion', $usuario->id_profesional) }}" class="inline"
+                                                  onsubmit="return confirm('¿Desea eliminar este usuario? Esta acción no se puede deshacer.');">
+                                                @csrf
+                                                @method('DELETE')
+                                                <button type="submit" 
+                                                        class="px-3 py-1 text-xs font-medium rounded-md bg-red-100 text-red-700 border border-red-300 hover:bg-red-200 transition"
+                                                        title="Eliminar usuario">
+                                                    Eliminar
+                                                </button>
+                                            </form>
+                                        @else
+                                            {{-- Botón Cambiar Estado (solo para usuarios con profesión asignada) --}}
+                                            {!! view('components.boton-estado', [
+                                                'activo' => $usuario->persona->activo,
+                                                'route' => route('usuarios.cambiarActivo', $usuario->id_profesional),
+                                                'text_activo' => 'Desactivar',
+                                                'text_inactivo' => 'Activar',
+                                                'message_activo' => '¿Desea desactivar este usuario?',
+                                                'message_inactivo' => '¿Desea activar este usuario?',
+                                            ])->render() !!}
+                                        @endif
                                     </div>
                                 </td>
 

--- a/routes/web.php
+++ b/routes/web.php
@@ -148,6 +148,8 @@ Route::get('/usuarios/crear', [ProfesionalController::class, 'crearEditar'])->na
 Route::post('/usuarios', [ProfesionalController::class, 'store'])->name('usuarios.store');
 Route::put('/usuarios/{id}', [ProfesionalController::class, 'update'])->name('usuarios.update');
 Route::patch('/usuarios/{id}/cambiar-estado', [ProfesionalController::class, 'cambiarActivo'])->name('usuarios.cambiarActivo');
+Route::post('/usuarios/{id}/reenviar-activacion', [ProfesionalController::class, 'reenviarMailActivacion'])->name('usuarios.reenviarActivacion');
+Route::delete('/usuarios/{id}/eliminar-sin-profesion', [ProfesionalController::class, 'eliminarSinProfesion'])->name('usuarios.eliminarSinProfesion');
 
 
 //Ruta Perfil


### PR DESCRIPTION
- Se agrega el boton "reenviar" para permitir el reenvío del correo de activación (elimina el token viejo y crea uno nuevo)
- Se extiende el plazo del token a 3 días.
- Se agrega la opción de eliminar el usuario QUE AÚN NO FUE ACTIVADO para que en caso de error se pueda eliminar a tiempo un acceso. 
- Se agrega la condición de eliminación a aquellos usuarios sin profesión asignada (es decir que aún no completaron el registro por email). Se usa la condición de "profesión" para que no figure el botón eliminar en usuarios inactivos. 
- Se cambia la forma en que se crean los nombres de usuario, ahora es primerNombre.primerApellido